### PR TITLE
Fix item count in mail send

### DIFF
--- a/MailBookKeeper.toc
+++ b/MailBookKeeper.toc
@@ -1,7 +1,7 @@
 ## Interface: 90002
 ## X-Min-Interface: 90001
 ## Title: Mail BookKeeper
-## Version: 1.2.6.release
+## Version: 1.2.7.release
 ## Notes: Tracks incoming and outgoing mails, trades 
 ## Author: polarkreis@web.de
 ## SavedVariables: MailBookKeeperHistory, MailBookKeeperOptions

--- a/core.lua
+++ b/core.lua
@@ -348,7 +348,7 @@ local function ProcessInboxMail(index)
 	
 	Transaction.Items = {};
 	for i=1,itemCount do		
-		local Name, itemTexture, Count, quality, canUse = GetInboxItem(index, i);
+        local Name, itemId, itemTexture, Count, quality, canUse = GetInboxItem(index, i);
 		if Name then
 			local NewItem= {};
 			NewItem.Name=Name;

--- a/core.lua
+++ b/core.lua
@@ -306,7 +306,7 @@ end;
 
 local function FormatMoneyTostring(ammount,category)
    local outstring="";
-   ammount = ammount or 0;
+   ammount = tonumber(ammount) or 0;
    if (ammount>=0) or (mooptions[category].Zero) then
       if mooptions[category].Graphics then
          outstring=GetCoinTextureString (ammount+0.0001);
@@ -650,7 +650,7 @@ end;
 local function UpdateSendMailitemsInfo()
    outgoingmailitems = {};
    for index=1, 12 do 
-		local Name, Texture, Count, Quality = GetSendMailItem (index); 
+		local Name, itemId, Texture, Count, Quality = GetSendMailItem (index);
 		if Name then    
 			local ItemAlreadyInList = false;	
 		    for inindex=1,#outgoingmailitems do

--- a/core.lua
+++ b/core.lua
@@ -496,6 +496,7 @@ local mailhistorycols = {
      end;
 
 	-- cvt
+	--[[
 	  tinsert(testdata, {cols = {
 		{value = ""},
 		{value = ""},
@@ -508,7 +509,7 @@ local mailhistorycols = {
 		{value = ""},
 		{value = ""}
 		}});
-
+	]]
 	   mailhistoryST:SetData(testdata);
 
 local STFilter=function (self, row)


### PR DESCRIPTION
I was getting two odd issues with the mod:
1- When mailing items, I was getting a garbage quantity, such as `[Pallid Bone]x432781` instead of `[Pallid Bone]x40`.
2- When viewing the history, I would get an error about concatenating 'nil'.

This fixes both of those issues.  The second issue actually goes away with the removal of the test data, but I left the conversion from string to number in for currency formatting as a "just in case."